### PR TITLE
mark Worker as Send

### DIFF
--- a/src/features/worker.rs
+++ b/src/features/worker.rs
@@ -97,6 +97,8 @@ pub struct Worker {
     sender: WorkerMessageSender,     // Where we send the results of our work
 }
 
+unsafe impl Send for Worker {}
+
 impl Worker {
     pub(crate) fn new(
         plugin_is_alive: Arc<Mutex<bool>>,

--- a/tests/worker_test.rs
+++ b/tests/worker_test.rs
@@ -213,7 +213,12 @@ fn test_sampler() {
     let outputs = run_instance_with_input_sequence(&mut instance, &features, input);
     assert_silence(outputs);
 
-    worker_manager.run_workers();
+    // The worker is probably going to run in some other thread,
+    // so this proves that both Worker & WorkerManager are Send.
+    let thread = std::thread::spawn(move || {
+        worker_manager.run_workers();
+    });
+    thread.join().unwrap();
 
     let outputs = run_instance_with_single_midi_note_input(&mut instance, &features);
     assert_silence(outputs);


### PR DESCRIPTION
Quick follow up PR on the Worker stuff. I realized when actually using the WorkerManager that it was not possible to pass off between threads due to the Worker struct containing `*mut c_void` fields. So, this should take care of that.