### PR TITLE
Support mod devices CV port

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@ impl World {
                             && class != common_uris.control_port_uri
                             && class != common_uris.atom_port_uri
                             && class != common_uris.cv_port_uri
+                            && class != common_uris.mod_cv_port_uri
                         {
                             error!("Port class {:?} is not supported.", class);
                             return false;
@@ -240,6 +241,7 @@ struct CommonUris {
     audio_port_uri: lilv::node::Node,
     atom_port_uri: lilv::node::Node,
     cv_port_uri: lilv::node::Node,
+    mod_cv_port_uri: lilv::node::Node,
     worker_schedule_feature_uri: lilv::node::Node,
 }
 
@@ -252,6 +254,7 @@ impl CommonUris {
             audio_port_uri: world.new_uri("http://lv2plug.in/ns/lv2core#AudioPort"),
             atom_port_uri: world.new_uri("http://lv2plug.in/ns/ext/atom#AtomPort"),
             cv_port_uri: world.new_uri("http://lv2plug.in/ns/lv2core#CVPort"),
+            mod_cv_port_uri: world.new_uri("http://moddevices.com/ns/mod#CVPort"),
             worker_schedule_feature_uri: world.new_uri("http://lv2plug.in/ns/ext/worker#schedule"),
         }
     }


### PR DESCRIPTION
Mod devices define their own sub class of CVPort here: https://moddevices.github.io/mod-sdk/mod/#CVPort

This makes it possible to load plugins like [Cardinal](https://github.com/DISTRHO/Cardinal) that define the mod CVPort. That plugin actually lists both the lv2:CVPort and mod:CVPort in the manifest file:
```
    [
        a lv2:InputPort, lv2:CVPort, mod:CVPort ;
        lv2:index 8 ;
        lv2:symbol "lv2_cv_in_1" ;
        lv2:name "CV Input 1" ;
        lv2:minimum 0.0 ;
        lv2:maximum 10.0 ;
        lv2:portProperty lv2:connectionOptional;
    ]
```

Perhaps there is an alternative way to accept plugins like this since at least one of the port properties matches the accepted port types? I imagine there could be many more plugins like this that define their own port subclasses but which are entirely compatible with livi.